### PR TITLE
ブログの削除を可能にした

### DIFF
--- a/api/.env.local
+++ b/api/.env.local
@@ -1,6 +1,6 @@
 APP_NAME=Blog
 APP_ENV=local
-APP_KEY=base64:LqUbz3N8WzpCaTSoZiHaMDsw2j7ZeT537X3xz3ubRdE=
+APP_KEY=base64:bcvC4L0eLhNaWo7khEbC+FiUyHC2BMNfmPZfuv+l4EE=
 APP_DEBUG=true
 APP_URL=http://localhost:8000
 

--- a/api/app/Http/Controllers/Blog/AdminBlogController.php
+++ b/api/app/Http/Controllers/Blog/AdminBlogController.php
@@ -4,21 +4,26 @@ namespace App\Http\Controllers\Blog;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Blog\Admin\CreateBlogRequest;
+use App\Http\Requests\Blog\Admin\DeleteBlogRequest;
 use App\Http\Requests\Blog\Admin\EditBlogMainImageRequest;
 use App\Http\Requests\Blog\Admin\EditBlogRequest;
 use Packages\Service\Blog\Query\InitBlogService;
 use Packages\Service\Blog\Query\InProgressBlogService;
+use Packages\Service\Blog\Query\DeleteBlogService;
 
 class AdminBlogController extends Controller {
     private InitBlogService $initBlogService;
     private InProgressBlogService $inProgressBlogService;
+    private DeleteBlogService $deleteBlogService;
 
     public function __construct(
         InitBlogService $initBlogService,
-        InProgressBlogService $inProgressBlogService
+        InProgressBlogService $inProgressBlogService,
+        DeleteBlogService $deleteBlogService
     ) {
         $this->initBlogService       = $initBlogService;
         $this->inProgressBlogService = $inProgressBlogService;
+        $this->deleteBlogService     = $deleteBlogService;
     }
 
     public function createBlog(CreateBlogRequest $request): void {
@@ -31,5 +36,9 @@ class AdminBlogController extends Controller {
 
     public function editBlogMainImage(EditBlogMainImageRequest $request): void {
         $this->inProgressBlogService->editBlogIcon($request->ofDomain());
+    }
+
+    public function deleteBlog(DeleteBlogRequest $request): void {
+        $this->deleteBlogService->deleteBlog($request->ofDomain());
     }
 }

--- a/api/app/Http/Requests/Blog/Admin/DeleteBlogRequest.php
+++ b/api/app/Http/Requests/Blog/Admin/DeleteBlogRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Blog\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Packages\Domain\Blog\ValueObjects\BlogId;
+
+class DeleteBlogRequest extends FormRequest {
+    public function authorize(): bool {
+        return true;
+    }
+
+    public function rules(): array {
+        return [
+        ];
+    }
+
+    public function ofDomain(): BlogId {
+        return BlogId::of($this->blogId);
+    }
+}

--- a/api/app/Http/Requests/Blog/Admin/EditBlogRequest.php
+++ b/api/app/Http/Requests/Blog/Admin/EditBlogRequest.php
@@ -3,10 +3,10 @@
 namespace App\Http\Requests\Blog\Admin;
 
 use Illuminate\Foundation\Http\FormRequest;
-use Packages\Domain\Blog\Entities\InitBlog;
 use Packages\Domain\Blog\Entities\InProgressBlog;
 use Packages\Domain\Blog\ValueObjects\BlogId;
 use Packages\Domain\Blog\ValueObjects\Body;
+use Packages\Domain\Blog\ValueObjects\IsActive;
 use Packages\Domain\Blog\ValueObjects\Title;
 
 class EditBlogRequest extends FormRequest {
@@ -24,6 +24,7 @@ class EditBlogRequest extends FormRequest {
             BlogId::of($this->blogId),
             Title::of($this->title),
             Body::of($this->body),
+            IsActive::of($this->isActive)
         );
     }
 }

--- a/api/packages/Domain/Blog/Entities/InProgressBlog.php
+++ b/api/packages/Domain/Blog/Entities/InProgressBlog.php
@@ -4,21 +4,25 @@ namespace Packages\Domain\Blog\Entities;
 
 use Packages\Domain\Blog\ValueObjects\BlogId;
 use Packages\Domain\Blog\ValueObjects\Body;
+use Packages\Domain\Blog\ValueObjects\IsActive;
 use Packages\Domain\Blog\ValueObjects\Title;
 
 final class InProgressBlog {
     private BlogId $blogId;
     private Title $title;
     private Body $body;
+    private IsActive $isActive;
 
     public function __construct(
         BlogId $blogId,
         Title $title,
         Body $body,
+        IsActive $isActive
     ) {
         $this->blogId     = $blogId;
         $this->title      = $title;
         $this->body       = $body;
+        $this->isActive   = $isActive;
     }
 
     public function blogId(): BlogId {
@@ -31,5 +35,9 @@ final class InProgressBlog {
 
     public function body(): Body {
         return $this->body;
+    }
+
+    public function isActive(): IsActive {
+        return $this->isActive;
     }
 }

--- a/api/packages/Domain/Blog/ValueObjects/IsActive.php
+++ b/api/packages/Domain/Blog/ValueObjects/IsActive.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Packages\Domain\Blog\ValueObjects;
+
+use Packages\Domain\Boolean;
+
+final class IsActive extends Boolean {
+    protected string $name = '公開・非公開';
+}

--- a/api/packages/Domain/Boolean.php
+++ b/api/packages/Domain/Boolean.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Packages\Domain;
+
+use Validator;
+
+abstract class Boolean {
+    protected bool $value;
+
+    protected string $name;
+
+    private function __construct($value) {
+        Validator::make(
+            [$this->name => $value],
+            [$this->name => ['boolean']]
+        )->validate();
+
+        $this->value = $value;
+    }
+
+    public function value(): bool {
+        return $this->value;
+    }
+
+    public static function of($value): Boolean {
+        return new static($value);
+    }
+}

--- a/api/packages/Infrastructure/Eloquent/Blog/Blog.php
+++ b/api/packages/Infrastructure/Eloquent/Blog/Blog.php
@@ -27,6 +27,10 @@ class Blog extends Model {
         return $this->hasOne(BlogContent::class, 'blogId', 'blogId');
     }
 
+    public function active(): HasOne {
+        return $this->hasOne(ActiveBlog::class, 'blogId', 'blogId');
+    }
+
     protected static function newFactory(): BlogFactory {
         return new BlogFactory();
     }

--- a/api/packages/Infrastructure/Repositories/Blog/DeleteBlogRepository.php
+++ b/api/packages/Infrastructure/Repositories/Blog/DeleteBlogRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Packages\Infrastructure\Repositories\Blog;
+
+use Carbon\Carbon;
+use DB;
+use Packages\Domain\Blog\ValueObjects\BlogId;
+
+final class DeleteBlogRepository {
+    public function deleteBlog(BlogId $blogId): void {
+        DB::transaction(function () use ($blogId) {
+            DB::delete('
+                DELETE FROM activeBlogs
+                WHERE
+                    blogId = ?
+            ', [$blogId->value()]);
+            DB::delete('
+                DELETE FROM nonActiveBlogs
+                WHERE
+                    blogId = ?
+            ', [$blogId->value()]);
+
+            DB::delete('
+                DELETE FROM blogContents
+                WHERE
+                    blogId = ?
+            ', [$blogId->value()]);
+            DB::delete('
+                DELETE FROM blogs
+                WHERE
+                    blogId = ?
+            ', [$blogId->value()]);
+        });
+    }
+}

--- a/api/packages/Service/Blog/Query/DeleteBlogService.php
+++ b/api/packages/Service/Blog/Query/DeleteBlogService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Packages\Service\Blog\Query;
+
+use Packages\Domain\Blog\ValueObjects\BlogId;
+use Packages\Infrastructure\Repositories\Blog\DeleteBlogRepository;
+
+final class DeleteBlogService {
+    private DeleteBlogRepository $deleteBlogRepository;
+
+    public function __construct(
+        DeleteBlogRepository $deleteBlogRepository,
+    ) {
+        $this->deleteBlogRepository = $deleteBlogRepository;
+    }
+
+    public function deleteBlog(BlogId $blogId): void {
+        $this->deleteBlogRepository->deleteBlog($blogId);
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -22,6 +22,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::prefix('/blogs')->group(function () {
         Route::post('/', [AdminBlogController::class, 'createBlog']);
         Route::put('/', [AdminBlogController::class, 'editBlog']);
+        Route::delete('/', [AdminBlogController::class, 'deleteBlog']);
         Route::put('/mainImage', [AdminBlogController::class, 'editBlogMainImage']);
     });
 });

--- a/api/tests/Feature/Blog/Admin/DeleteBlogTest.php
+++ b/api/tests/Feature/Blog/Admin/DeleteBlogTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature\Blog\Admin;
+
+use Packages\Infrastructure\Eloquent\Blog\Blog;
+use Tests\DBSetUpTestCase;
+
+class DeleteBlogTest extends DBSetUpTestCase {
+    public function test_ブログの削除を行う(): void {
+        $preBlog = Blog::first();
+
+        $request  = [
+            'blogId' => $preBlog->blogId,
+        ];
+
+        $response = $this->delete('/api/blogs', $request);
+        $response->assertOk();
+
+        $this->assertTrue(Blog::find($preBlog->blogId) === null);
+    }
+}

--- a/api/tests/Feature/Blog/Admin/EditBlogTest.php
+++ b/api/tests/Feature/Blog/Admin/EditBlogTest.php
@@ -16,6 +16,7 @@ class EditBlogTest extends DBSetUpTestCase {
             'blogId'    => $blog->blogId,
             'title'     => 'タイトル',
             'body'      => 'ボディー',
+            'isActive'  => false,
         ];
 
         $response = $this->put('/api/blogs', $request);
@@ -24,9 +25,10 @@ class EditBlogTest extends DBSetUpTestCase {
         $blog = Blog::find($blog->blogId);
 
         $this->assertEquals($request, [
-            'blogId' => $blog->blogId,
-            'title'  => $blog->content->title,
-            'body'   => $blog->content->body,
+            'blogId'   => $blog->blogId,
+            'title'    => $blog->content->title,
+            'body'     => $blog->content->body,
+            'isActive' => $blog->active !== null,
         ]);
     }
 }


### PR DESCRIPTION
# 概要
ブログの削除を可能にした

# 変更内容
- ブログの削除を可能にした
- ブログの編集時に公開非公開の操作を可能にした

# チェック項目
- [x] apiFormat.shを実行しました。
- [x] 開発サーバーを起動して動作確認をしました。